### PR TITLE
Allow build for x86_64-unknown-linux-musl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: CI build
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-unknown-linux-gnu
@@ -33,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install cross-compilation tools
-        uses: taiki-e/setup-cross-toolchain-action@v1
+        uses: k0lter/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
Allow build for x86_64-unknown-linux-musl binaries using a fork of taiki-e/setup-cross-toolchain-action until the related pull request (https://github.com/taiki-e/setup-cross-toolchain-action/pull/6) will be merged